### PR TITLE
Removed trailing space from ".prettierignore " file name

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.*
+coverage

--- a/.prettierignore 
+++ b/.prettierignore 
@@ -1,2 +1,0 @@
-.*
-coverage


### PR DESCRIPTION
The `.prettierignore ` filename ends with a space, which is preventing me from checking out the repository (could be a Windows limitation).

![image](https://github.com/reduckted/comment-parser/assets/10321525/41eb9528-404d-41a4-aa4a-ee20db682041)
